### PR TITLE
acts-as-taggable-on(gem)導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,10 +18,10 @@ gem "puma", "~> 5.0"
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "importmap-rails"
 
-# Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
+# Hotwire"s SPA-like page accelerator [https://turbo.hotwired.dev]
 gem "turbo-rails"
 
-# Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
+# Hotwire"s modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"
 
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
@@ -81,3 +81,5 @@ gem "slim-rails"
 gem "html2slim"
 
 gem "bootstrap"
+
+gem "acts-as-taggable-on", "~> 9.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    acts-as-taggable-on (9.0.1)
+      activerecord (>= 6.0, < 7.1)
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
@@ -293,6 +295,7 @@ PLATFORMS
   x86_64-darwin-22
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 9.0)
   bootsnap
   bootstrap
   capybara

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Note < ApplicationRecord
   acts_as_taggable_on :tags
 

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,4 +1,6 @@
 class Note < ApplicationRecord
+  acts_as_taggable_on :tags
+
   validates :title, presence: true
 
   has_many :phrases, dependent: :destroy

--- a/app/models/phrase.rb
+++ b/app/models/phrase.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Phrase < ApplicationRecord
   validates :expression_en, presence: true
   validates :expression_ja, presence: true

--- a/db/migrate/20230522010557_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230522010557_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+class ActsAsTaggableOnMigration < ActiveRecord::Migration[6.0]
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20230522010558_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230522010558_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+class AddMissingUniqueIndices < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20230522010559_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230522010559_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20230522010560_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230522010560_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+class AddMissingTaggableIndex < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20230522010561_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230522010561_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+
+class ChangeCollationForTagNames < ActiveRecord::Migration[6.0]
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20230522010562_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230522010562_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+class AddMissingIndexesOnTaggings < ActiveRecord::Migration[6.0]
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                 :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                   :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                               :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                         name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                name: 'taggings_idy'
+    end
+  end
+end

--- a/db/migrate/20230522010563_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230522010563_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 7)
+class AddTenantToTaggings < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.taggings_table, :tenant, :string, limit: 128
+    add_index ActsAsTaggableOn.taggings_table, :tenant unless index_exists? ActsAsTaggableOn.taggings_table, :tenant
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, :tenant
+    remove_column ActsAsTaggableOn.taggings_table, :tenant
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_19_055737) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_22_010563) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,5 +32,37 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_19_055737) do
     t.index ["note_id"], name: "index_phrases_on_note_id"
   end
 
+  create_table "taggings", force: :cascade do |t|
+    t.bigint "tag_id"
+    t.string "taggable_type"
+    t.bigint "taggable_id"
+    t.string "tagger_type"
+    t.bigint "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at", precision: nil
+    t.string "tenant", limit: 128
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+    t.index ["tagger_type", "tagger_id"], name: "index_taggings_on_tagger_type_and_tagger_id"
+    t.index ["tenant"], name: "index_taggings_on_tenant"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   add_foreign_key "phrases", "notes"
+  add_foreign_key "taggings", "tags"
 end

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :note do
     title { 'メモ１' }
-    text_en { 'There are apples on that tree.' } 
+    text_en { 'There are apples on that tree.' }
     text_ja { 'あの木にはりんごがなっています。' }
     free_text { 'テスト用' }
   end

--- a/spec/factories/phrases.rb
+++ b/spec/factories/phrases.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :phrase do
-    expression_en { 'Apple' } 
+    expression_en { 'Apple' }
     expression_ja { 'りんご' }
     note
   end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Note, type: :model do

--- a/spec/models/phrase_spec.rb
+++ b/spec/models/phrase_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Phrase, type: :model do


### PR DESCRIPTION
レビューをお願いいたします。

## 作業内容
- [x] [acts-as-taggable-on](https://github.com/mbleigh/acts-as-taggable-on)のインストール
- [x] db:migrate実行
- [x] Noteモデルへのタグ機能追加
- [x] RuboCopによるコード修正（モデル作成・テスト時のファイルを含む）

## テーブル一覧
```
parallel_note_development=# \dt
                List of relations
 Schema |         Name         | Type  |  Owner  
--------+----------------------+-------+---------
 public | ar_internal_metadata | table | t.momma
 public | notes                | table | t.momma
 public | phrases              | table | t.momma
 public | schema_migrations    | table | t.momma
 public | taggings             | table | t.momma
 public | tags                 | table | t.momma
(6 rows)
```