### PR TITLE
N+1問題の解消

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -2,7 +2,7 @@
 
 class NotesController < ApplicationController
   def index
-    @notes = Note.all.includes(:tags)
+    @notes = Note.preload(:tags)
   end
 
   def new

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -2,7 +2,7 @@
 
 class NotesController < ApplicationController
   def index
-    @notes = Note.all
+    @notes = Note.all.includes(:tags)
   end
 
   def new

--- a/app/controllers/phrases_controller.rb
+++ b/app/controllers/phrases_controller.rb
@@ -2,6 +2,6 @@
 
 class PhrasesController < ApplicationController
   def index
-    @phrases = Phrase.eager_load(:note)
+    @phrases = Phrase.preload(:note)
   end
 end

--- a/app/controllers/phrases_controller.rb
+++ b/app/controllers/phrases_controller.rb
@@ -2,6 +2,6 @@
 
 class PhrasesController < ApplicationController
   def index
-    @phrases = Phrase.joins(:note)
+    @phrases = Phrase.eager_load(:note)
   end
 end

--- a/app/views/notes/_taglist.html.slim
+++ b/app/views/notes/_taglist.html.slim
@@ -1,2 +1,2 @@
-- tag_list.each do |tag|
+- tags.pluck(:name).each do |tag|
   span.badge.bg-primary.mx-1= tag

--- a/app/views/notes/index.html.slim
+++ b/app/views/notes/index.html.slim
@@ -12,6 +12,6 @@ div
       - @notes.each do |note|
         tr
           td= note.title
-          td= render "notes/taglist", tag_list: note.tag_list
+          td= render "notes/taglist", tags: note.tags
           td= note.text_en.truncate(50)
           td= l note.created_at, format: :date


### PR DESCRIPTION
## 作業内容
- [x] 語句一覧画面におけるN+1問題対応の修正
- [x] 一覧画面でのタグ表示のN+1問題を解消

## メモ一覧ログ
### 変更前
```
Started GET "/notes" for ::1 at 2023-05-29 10:30:01 +0900
Processing by NotesController#index as HTML
  Rendering layout layouts/application.html.slim
  Rendering notes/index.html.slim within layouts/application
  Note Load (0.3ms)  SELECT "notes".* FROM "notes"
  ↳ app/views/notes/index.html.slim:12
  ActsAsTaggableOn::Tagging Load (0.3ms)  SELECT "taggings".* FROM "taggings" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2  [["taggable_id", 1], ["taggable_type", "Note"]]
  ↳ app/views/notes/index.html.slim:15
  ActsAsTaggableOn::Tag Load (0.4ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2 AND (taggings.context = 'tags' AND taggings.tagger_id IS NULL)  [["taggable_id", 1], ["taggable_type", "Note"]]
  ↳ app/views/notes/index.html.slim:15
  Rendered notes/_taglist.html.slim (Duration: 0.0ms | Allocations: 11)
  ActsAsTaggableOn::Tagging Load (0.2ms)  SELECT "taggings".* FROM "taggings" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2  [["taggable_id", 2], ["taggable_type", "Note"]]
  ↳ app/views/notes/index.html.slim:15
  ActsAsTaggableOn::Tag Load (0.4ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2 AND (taggings.context = 'tags' AND taggings.tagger_id IS NULL)  [["taggable_id", 2], ["taggable_type", "Note"]]
  ↳ app/views/notes/index.html.slim:15
  Rendered notes/_taglist.html.slim (Duration: 0.0ms | Allocations: 10)
  ActsAsTaggableOn::Tagging Load (0.3ms)  SELECT "taggings".* FROM "taggings" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2  [["taggable_id", 3], ["taggable_type", "Note"]]
  ↳ app/views/notes/index.html.slim:15
  ActsAsTaggableOn::Tag Load (0.5ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2 AND (taggings.context = 'tags' AND taggings.tagger_id IS NULL)  [["taggable_id", 3], ["taggable_type", "Note"]]
  ↳ app/views/notes/index.html.slim:15
  Rendered notes/_taglist.html.slim (Duration: 0.0ms | Allocations: 10)
  Rendered notes/index.html.slim within layouts/application (Duration: 11.7ms | Allocations: 6752)
  Rendered layout layouts/application.html.slim (Duration: 18.7ms | Allocations: 12451)
Completed 200 OK in 20ms (Views: 16.8ms | ActiveRecord: 2.3ms | Allocations: 12730)
```

### 変更後
```
Started GET "/notes" for ::1 at 2023-05-29 11:19:31 +0900
Processing by NotesController#index as HTML
  Rendering layout layouts/application.html.slim
  Rendering notes/index.html.slim within layouts/application
  Note Load (0.2ms)  SELECT "notes".* FROM "notes"
  ↳ app/views/notes/index.html.slim:12
  ActsAsTaggableOn::Tagging Load (0.3ms)  SELECT "taggings".* FROM "taggings" WHERE "taggings"."taggable_type" = $1 AND "taggings"."context" = $2 AND "taggings"."taggable_id" IN ($3, $4, $5)  [["taggable_type", "Note"], ["context", "tags"], ["taggable_id", 1], ["taggable_id", 2], ["taggable_id", 3]]
  ↳ app/views/notes/index.html.slim:12
  ActsAsTaggableOn::Tag Load (0.3ms)  SELECT "tags".* FROM "tags" WHERE "tags"."id" IN ($1, $2, $3, $4)  [["id", 1], ["id", 2], ["id", 3], ["id", 4]]
  ↳ app/views/notes/index.html.slim:12
  Rendered notes/_taglist.html.slim (Duration: 0.1ms | Allocations: 24)
  Rendered notes/_taglist.html.slim (Duration: 0.0ms | Allocations: 21)
  Rendered notes/_taglist.html.slim (Duration: 0.0ms | Allocations: 24)
  Rendered notes/index.html.slim within layouts/application (Duration: 6.4ms | Allocations: 4168)
  Rendered layout layouts/application.html.slim (Duration: 14.2ms | Allocations: 9854)
Completed 200 OK in 15ms (Views: 13.8ms | ActiveRecord: 0.8ms | Allocations: 10139)
```

## 語句一覧ログ
### 変更前
```
Started GET "/phrases" for ::1 at 2023-05-29 10:30:46 +0900
Processing by PhrasesController#index as HTML
  Rendering layout layouts/application.html.slim
  Rendering phrases/index.html.slim within layouts/application
  Phrase Load (1.2ms)  SELECT "phrases".* FROM "phrases" INNER JOIN "notes" ON "notes"."id" = "phrases"."note_id"
  ↳ app/views/phrases/index.html.slim:11
  Note Load (0.2ms)  SELECT "notes".* FROM "notes" WHERE "notes"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  ↳ app/views/phrases/index.html.slim:15
  CACHE Note Load (0.0ms)  SELECT "notes".* FROM "notes" WHERE "notes"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  ↳ app/views/phrases/index.html.slim:15
  Note Load (0.2ms)  SELECT "notes".* FROM "notes" WHERE "notes"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  ↳ app/views/phrases/index.html.slim:15
  CACHE Note Load (0.0ms)  SELECT "notes".* FROM "notes" WHERE "notes"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  ↳ app/views/phrases/index.html.slim:15
  CACHE Note Load (0.0ms)  SELECT "notes".* FROM "notes" WHERE "notes"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  ↳ app/views/phrases/index.html.slim:15
  CACHE Note Load (0.0ms)  SELECT "notes".* FROM "notes" WHERE "notes"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  ↳ app/views/phrases/index.html.slim:15
  Note Load (0.2ms)  SELECT "notes".* FROM "notes" WHERE "notes"."id" = $1 LIMIT $2  [["id", 3], ["LIMIT", 1]]
  ↳ app/views/phrases/index.html.slim:15
  CACHE Note Load (0.0ms)  SELECT "notes".* FROM "notes" WHERE "notes"."id" = $1 LIMIT $2  [["id", 3], ["LIMIT", 1]]
  ↳ app/views/phrases/index.html.slim:15
  CACHE Note Load (0.0ms)  SELECT "notes".* FROM "notes" WHERE "notes"."id" = $1 LIMIT $2  [["id", 3], ["LIMIT", 1]]
  ↳ app/views/phrases/index.html.slim:15
  Rendered phrases/index.html.slim within layouts/application (Duration: 22.3ms | Allocations: 17977)
  Rendered layout layouts/application.html.slim (Duration: 29.9ms | Allocations: 23798)
Completed 200 OK in 33ms (Views: 27.3ms | ActiveRecord: 3.8ms | Allocations: 25156)
```

### 変更後
```
Started GET "/phrases" for ::1 at 2023-05-29 11:20:08 +0900
Processing by PhrasesController#index as HTML
  Rendering layout layouts/application.html.slim
  Rendering phrases/index.html.slim within layouts/application
  Phrase Load (0.5ms)  SELECT "phrases".* FROM "phrases"
  ↳ app/views/phrases/index.html.slim:11
  Note Load (0.3ms)  SELECT "notes".* FROM "notes" WHERE "notes"."id" IN ($1, $2, $3)  [["id", 1], ["id", 2], ["id", 3]]
  ↳ app/views/phrases/index.html.slim:11
  Rendered phrases/index.html.slim within layouts/application (Duration: 12.3ms | Allocations: 11278)
  Rendered layout layouts/application.html.slim (Duration: 20.6ms | Allocations: 17109)
Completed 200 OK in 25ms (Views: 19.1ms | ActiveRecord: 2.6ms | Allocations: 18472)
```