### PR TITLE
メモ削除機能の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,7 @@ h2 {
 .flex {
   display: flex;
 }
+
+.w80px {
+  width: 80px;
+}

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -39,6 +39,12 @@ class NotesController < ApplicationController
     end
   end
 
+  def destroy
+    note = Note.find(params[:id])
+    note.destroy
+    redirect_to notes_url, notice: 'メモを削除しました。', status: :see_other
+  end
+
   private
 
   def note_form_params

--- a/app/views/notes/show.html.slim
+++ b/app/views/notes/show.html.slim
@@ -1,8 +1,8 @@
 .d-flex.justify-content-between.mt-2
   h1= @note.title
   .mt-2
-    = link_to "編集", edit_note_path, class: "btn btn-primary me-3", style: "width:80px"
-    = link_to "削除", @note, data: { turbo_method: :delete, turbo_confirm: "メモを削除します。よろしいですか？" }, class: "btn btn-danger", style: "width:80px"
+    = link_to "編集", edit_note_path, class: "btn btn-primary me-3 w80px"
+    = link_to "削除", @note, data: { turbo_method: :delete, turbo_confirm: "メモを削除します。よろしいですか？" }, class: "btn btn-danger w80px"
 
 .d-flex.flex-row
   | タグ：

--- a/app/views/notes/show.html.slim
+++ b/app/views/notes/show.html.slim
@@ -1,6 +1,8 @@
 .d-flex.justify-content-between.mt-2
   h1= @note.title
-  .mt-2= link_to "編集", edit_note_path, class: "btn btn-primary", style: "width:80px"
+  .mt-2
+    = link_to "編集", edit_note_path, class: "btn btn-primary me-3", style: "width:80px"
+    = link_to "削除", @note, data: { turbo_method: :delete, turbo_confirm: "メモを削除します。よろしいですか？" }, class: "btn btn-danger", style: "width:80px"
 
 .d-flex.flex-row
   | タグ：

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -1,0 +1,1 @@
+ActsAsTaggableOn.remove_unused_tags = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :notes, only: [:index, :show, :new, :create, :edit, :update]
+  resources :notes
   root to: 'notes#index'
   
   get 'phrases', to: 'phrases#index'


### PR DESCRIPTION
レビューをお願いいたします。

## 作業内容
- [x] ルーティングの設定
- [x] 閲覧画面へ削除ボタンを追加
- [x] notesコントローラへdestroyメソッドを実装
- [x] ボタンのスタイルをCSSに記述
- [x] メモ削除時に未使用タグが削除されるよう変更※

※参考：https://github.com/mbleigh/acts-as-taggable-on/wiki

## 削除時ポップアップ
<img width="1440" alt="スクリーンショット 2023-05-31 13 36 12" src="https://github.com/tmonma-lux/parallel_note/assets/132245602/b4424d20-da3b-4e5e-ad34-f987235855b4">

## 削除完了メッセージ
<img width="1440" alt="スクリーンショット 2023-05-31 13 37 01" src="https://github.com/tmonma-lux/parallel_note/assets/132245602/409b2cbd-59f1-4dd3-a60a-76285c3880cc">
