### PR TITLE
メモ検索機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,16 +2,16 @@
 
 class ApplicationController < ActionController::Base
   unless Rails.env.development?
-    rescue_from ActiveRecord::RecordNotFound, with: :redirect_on_404
-    rescue_from ActionController::RoutingError, with: :redirect_on_404
-    rescue_from Exception, with: :redirect_on_500
+    rescue_from ActiveRecord::RecordNotFound, with: :redirect_on_404err
+    rescue_from ActionController::RoutingError, with: :redirect_on_404err
+    rescue_from Exception, with: :redirect_on_500err
   end
 
-  def redirect_on_404
+  def redirect_on_404err
     redirect_to root_url, alert: 'ページが見つかりませんでした。'
   end
 
-  def redirect_on_500
+  def redirect_on_500err
     redirect_to root_url, alert: 'サーバーでエラーが発生しました。'
   end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -10,8 +10,8 @@ class NotesController < ApplicationController
   end
 
   def search
-    @notes = Note.search(params[:keyword])
-    @keyword = params[:keyword]
+    @notes = Note.search(params[:query])
+    @query = params[:query]
   end
 
   def new

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -10,7 +10,8 @@ class NotesController < ApplicationController
   end
 
   def search
-    @notes = Note.search(params[:query])
+    redirect_to notes_url if params[:query].empty? && params[:tags].nil?
+    @notes = Note.search(params[:query], params[:tags])
     @query = params[:query]
   end
 

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -9,6 +9,12 @@ class NotesController < ApplicationController
     @note = Note.find(params[:id])
   end
 
+  def search
+    @notes = Note.search(params[:keyword])
+    @keyword = params[:keyword]
+    render :index, status: :unprocessable_entity
+  end
+
   def new
     @note_form = NoteForm.new
   end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -12,7 +12,6 @@ class NotesController < ApplicationController
   def search
     @notes = Note.search(params[:keyword])
     @keyword = params[:keyword]
-    render :index, status: :unprocessable_entity
   end
 
   def new

--- a/app/forms/note_form.rb
+++ b/app/forms/note_form.rb
@@ -36,7 +36,7 @@ class NoteForm
       # すでに登録されている語句を削除
       @note.phrases.map(&:destroy!)
       # 語句とその意味がともに空欄のデータを削除
-      phrases.delete_if { |phrase_attrs| phrase_attrs[:expression_en].blank? && phrase_attrs[:expression_ja].blank? }
+      delete_blank_phrases
       # 語句が存在している場合は登録
       insert_new_phrases
     end
@@ -48,6 +48,10 @@ class NoteForm
 
   private
 
+  def delete_blank_phrases
+    phrases.delete_if { |phrase_attrs| phrase_attrs[:expression_en].blank? && phrase_attrs[:expression_ja].blank? }
+  end
+
   def insert_new_phrases
     return if phrases.empty?
 
@@ -58,12 +62,15 @@ class NoteForm
   def validate_phrases
     phrases.each do |phrase_attrs|
       if phrase_attrs[:expression_en].present? && phrase_attrs[:expression_ja].blank?
-        errors.add(:base, "#{NoteForm.human_attribute_name(:expression_en)}に対応する" \
-                          "#{NoteForm.human_attribute_name(:expression_ja)}を入力してください")
+        add_phrase_blank_err(:expression_en, :expression_ja)
       elsif phrase_attrs[:expression_en].blank? && phrase_attrs[:expression_ja].present?
-        errors.add(:base, "#{NoteForm.human_attribute_name(:expression_ja)}に対応する" \
-                          "#{NoteForm.human_attribute_name(:expression_en)}を入力してください")
+        add_phrase_blank_err(:expression_ja, :expression_en)
       end
     end
+  end
+
+  def add_phrase_blank_err(attr1, attr2)
+    errors.add(:base, "#{NoteForm.human_attribute_name(attr1)}に対応する" \
+                      "#{NoteForm.human_attribute_name(attr2)}を入力してください")
   end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -5,7 +5,11 @@ class Note < ApplicationRecord
 
   has_many :phrases, dependent: :destroy
 
-  def self.search(query)
-    where('title like?', "%#{query}%") | tagged_with(query)
+  def self.search(query, tags)
+    if tags.present?
+      where('title like?', "%#{query}%") & tagged_with(tags, any: true)
+    else
+      where('title like?', "%#{query}%")
+    end
   end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -5,7 +5,7 @@ class Note < ApplicationRecord
 
   has_many :phrases, dependent: :destroy
 
-  def self.search(keyword)
-    where('title like?', "%#{keyword}%") | tagged_with(keyword)
+  def self.search(query)
+    where('title like?', "%#{query}%") | tagged_with(query)
   end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -6,6 +6,6 @@ class Note < ApplicationRecord
   has_many :phrases, dependent: :destroy
 
   def self.search(keyword)
-    where("title like?", "%#{keyword}%")
+    where('title like?', "%#{keyword}%")
   end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -4,4 +4,8 @@ class Note < ApplicationRecord
   acts_as_taggable_on :tags
 
   has_many :phrases, dependent: :destroy
+
+  def self.search(keyword)
+    where("title like?", "%#{keyword}%")
+  end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -6,6 +6,6 @@ class Note < ApplicationRecord
   has_many :phrases, dependent: :destroy
 
   def self.search(keyword)
-    where('title like?', "%#{keyword}%")
+    where('title like?', "%#{keyword}%") | tagged_with(keyword)
   end
 end

--- a/app/views/notes/_notetable.html.slim
+++ b/app/views/notes/_notetable.html.slim
@@ -10,7 +10,7 @@
       - Note.tags_on(:tags).most_used(15).each do |tag|
         .form-check.form-check-inline
           = check_box_tag "tags[]", tag.name, params[:tags] && params[:tags].include?(tag.name), class: 'form-check-input'
-          = tag.name
+          = "#{tag.name}(#{tag.taggings_count})"
 
 .mt-2
   table.table.table-hover

--- a/app/views/notes/_notetable.html.slim
+++ b/app/views/notes/_notetable.html.slim
@@ -1,7 +1,7 @@
 = form_with url: search_notes_path, method: :get, local: true do |f|
   .row.mt-3.w-50
     .col
-      = f.text_field :query, class: "form-control", value: query, placeholder: "タイトルやタグを入力"
+      = f.text_field :query, class: "form-control", value: query, required: true, placeholder: "タイトルやタグを入力"
     = f.submit "検索", class: "btn btn-primary me-2", name: nil, style: "width:100px"
 
 .mt-2

--- a/app/views/notes/_notetable.html.slim
+++ b/app/views/notes/_notetable.html.slim
@@ -1,4 +1,4 @@
-= form_with url: search_path, method: :get, local: true do |f|
+= form_with url: search_notes_path, method: :get, local: true do |f|
   .row.mt-3.w-50
     .col
       = f.text_field :keyword, class: "form-control", value: keyword, placeholder: "タイトルやタグを入力"

--- a/app/views/notes/_notetable.html.slim
+++ b/app/views/notes/_notetable.html.slim
@@ -1,7 +1,7 @@
 = form_with url: search_notes_path, method: :get, local: true do |f|
   .row.mt-3.w-50
     .col
-      = f.text_field :keyword, class: "form-control", value: keyword, placeholder: "タイトルやタグを入力"
+      = f.text_field :query, class: "form-control", value: query, placeholder: "タイトルやタグを入力"
     = f.submit "検索", class: "btn btn-primary me-2", style: "width:100px"
 
 .mt-2

--- a/app/views/notes/_notetable.html.slim
+++ b/app/views/notes/_notetable.html.slim
@@ -2,7 +2,7 @@
   .row.mt-3.w-50
     .col
       = f.text_field :query, class: "form-control", value: query, placeholder: "タイトルやタグを入力"
-    = f.submit "検索", class: "btn btn-primary me-2", style: "width:100px"
+    = f.submit "検索", class: "btn btn-primary me-2", name: nil, style: "width:100px"
 
 .mt-2
   table.table.table-hover

--- a/app/views/notes/_notetable.html.slim
+++ b/app/views/notes/_notetable.html.slim
@@ -1,8 +1,15 @@
 = form_with url: search_notes_path, method: :get, local: true do |f|
   .row.mt-3.w-50
     .col
-      = f.text_field :query, class: "form-control", value: query, required: true, placeholder: "タイトルやタグを入力"
+      = f.text_field :query, class: "form-control", value: query, placeholder: "タイトルを入力"
     = f.submit "検索", class: "btn btn-primary me-2", name: nil, style: "width:100px"
+
+  .mt-2
+    | タグ絞り込み： 
+    - Note.tags_on(:tags).each do |tag|
+      .form-check.form-check-inline
+        = check_box_tag "tags[]", tag.name, params[:tags] && params[:tags].include?(tag.name), class: 'form-check-input'
+        = tag.name
 
 .mt-2
   table.table.table-hover

--- a/app/views/notes/_notetable.html.slim
+++ b/app/views/notes/_notetable.html.slim
@@ -4,12 +4,13 @@
       = f.text_field :query, class: "form-control", value: query, placeholder: "タイトルを入力"
     = f.submit "検索", class: "btn btn-primary me-2", name: nil, style: "width:100px"
 
-  .mt-2
+  .row.mt-2.ms-1
     | タグ絞り込み： 
-    - Note.tags_on(:tags).each do |tag|
-      .form-check.form-check-inline
-        = check_box_tag "tags[]", tag.name, params[:tags] && params[:tags].include?(tag.name), class: 'form-check-input'
-        = tag.name
+    .col
+      - Note.tags_on(:tags).each do |tag|
+        .form-check.form-check-inline
+          = check_box_tag "tags[]", tag.name, params[:tags] && params[:tags].include?(tag.name), class: 'form-check-input'
+          = tag.name
 
 .mt-2
   table.table.table-hover

--- a/app/views/notes/_notetable.html.slim
+++ b/app/views/notes/_notetable.html.slim
@@ -7,7 +7,7 @@
   .row.mt-2.ms-1
     | タグ絞り込み： 
     .col
-      - Note.tags_on(:tags).each do |tag|
+      - Note.tags_on(:tags).most_used(15).each do |tag|
         .form-check.form-check-inline
           = check_box_tag "tags[]", tag.name, params[:tags] && params[:tags].include?(tag.name), class: 'form-check-input'
           = tag.name

--- a/app/views/notes/_notetable.html.slim
+++ b/app/views/notes/_notetable.html.slim
@@ -1,0 +1,21 @@
+= form_with url: search_path, method: :get, local: true do |f|
+  .row.mt-3.w-50
+    .col
+      = f.text_field :keyword, class: "form-control", value: keyword, placeholder: "タイトルやタグを入力"
+    = f.submit "検索", class: "btn btn-primary me-2", style: "width:100px"
+
+.mt-2
+  table.table.table-hover
+    thead
+      tr
+        th= Note.human_attribute_name(:title)
+        th= I18n.t("tags_on.tag")
+        th= Note.human_attribute_name(:text_en) + "プレビュー"
+        th= Note.human_attribute_name(:created_at)
+    tbody
+      - notes.each do |note|
+        tr
+          td= link_to note.title, note
+          td= render "notes/taglist", tags: note.tags
+          td= note.text_en.truncate(50)
+          td= l note.created_at, format: :date

--- a/app/views/notes/index.html.slim
+++ b/app/views/notes/index.html.slim
@@ -1,3 +1,3 @@
 h1.mt-2 メモ一覧
 
-= render partial: 'notetable', locals: { notes: @notes, keyword: @keyword }
+= render partial: 'notetable', locals: { notes: @notes, query: @query }

--- a/app/views/notes/index.html.slim
+++ b/app/views/notes/index.html.slim
@@ -1,23 +1,3 @@
 h1.mt-2 メモ一覧
 
-= form_with url: search_path, method: :get, local: true do |f|
-  .row.mt-3.w-50
-    .col
-      = f.text_field :keyword, class: "form-control", value: @keyword, placeholder: "タイトルやタグを入力"
-    = f.submit "検索", class: "btn btn-primary me-2", style: "width:100px"
-
-.mt-2
-  table.table.table-hover
-    thead
-      tr
-        th= Note.human_attribute_name(:title)
-        th= I18n.t("tags_on.tag")
-        th= Note.human_attribute_name(:text_en) + "プレビュー"
-        th= Note.human_attribute_name(:created_at)
-    tbody
-      - @notes.each do |note|
-        tr
-          td= link_to note.title, note
-          td= render "notes/taglist", tags: note.tags
-          td= note.text_en.truncate(50)
-          td= l note.created_at, format: :date
+= render partial: 'notetable', locals: { notes: @notes, keyword: @keyword }

--- a/app/views/notes/index.html.slim
+++ b/app/views/notes/index.html.slim
@@ -1,6 +1,12 @@
 h1.mt-2 メモ一覧
 
-div
+= form_with url: search_path, method: :get, local: true do |f|
+  .row.mt-3.w-50
+    .col
+      = f.text_field :keyword, class: "form-control", value: @keyword, placeholder: "タイトルやタグを入力"
+    = f.submit "検索", class: "btn btn-primary me-2", style: "width:100px"
+
+.mt-2
   table.table.table-hover
     thead
       tr

--- a/app/views/notes/search.html.slim
+++ b/app/views/notes/search.html.slim
@@ -1,0 +1,3 @@
+h1.mt-2 メモ検索結果
+
+= render partial: 'notetable', locals: { notes: @notes, keyword: @keyword }

--- a/app/views/notes/search.html.slim
+++ b/app/views/notes/search.html.slim
@@ -1,3 +1,3 @@
 h1.mt-2 メモ検索結果
 
-= render partial: 'notetable', locals: { notes: @notes, keyword: @keyword }
+= render partial: 'notetable', locals: { notes: @notes, query: @query }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   resources :notes
   root to: 'notes#index'
+  get 'search', to: 'notes#search'
   
   get 'phrases', to: 'phrases#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,5 @@ Rails.application.routes.draw do
   
   get 'phrases', to: 'phrases#index'
 
-  get '*path', controller: 'application', action: 'redirect_on_404' unless Rails.env.development?
+  get '*path', controller: 'application', action: 'redirect_on_404err' unless Rails.env.development?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,11 @@
 Rails.application.routes.draw do
-  resources :notes
   root to: 'notes#index'
-  get 'search', to: 'notes#search'
-  
+  resources :notes do
+    collection do
+      get :search
+    end
+  end
+
   get 'phrases', to: 'phrases#index'
 
   get '*path', controller: 'application', action: 'redirect_on_404err' unless Rails.env.development?


### PR DESCRIPTION
レビューをお願いいたします。
## 作業内容
- [x] メモ一覧画面への検索フォーム追加
- [x] noteモデル，notesコントローラへの検索用メソッド追加
- [x] メモ一覧テーブルのパーシャル化，検索結果ビューの作成
- [x] タグ絞り込み機能の実装，表示上限の設定・各タグ使用数の表示

## 検索結果画面
### タイトル検索のみ
![スクリーンショット 2023-06-02 9 49 20](https://github.com/tmonma-lux/parallel_note/assets/132245602/1082356f-e401-415c-b687-8dd7b2e17bdf)

### タグ絞り込みのみ
![スクリーンショット 2023-06-02 9 49 31](https://github.com/tmonma-lux/parallel_note/assets/132245602/d7fcf379-1a53-4d0e-af61-364dc12698a1)

### タイトル検索＋タグ絞り込み
![スクリーンショット 2023-06-02 9 49 47](https://github.com/tmonma-lux/parallel_note/assets/132245602/6f363fd9-7a05-43d2-9aea-067fd1418ee6)

## RuboCop実行結果
```
Inspecting 18 files
..................

18 files inspected, no offenses detected
```