### PR TITLE
語句検索機能の実装

### DIFF
--- a/app/controllers/phrases_controller.rb
+++ b/app/controllers/phrases_controller.rb
@@ -4,4 +4,10 @@ class PhrasesController < ApplicationController
   def index
     @phrases = Phrase.preload(:note)
   end
+
+  def search
+    redirect_to phrases_url if params[:query].empty?
+    @phrases = Phrase.search(params[:query]).preload(:note)
+    @query = params[:query]
+  end
 end

--- a/app/models/phrase.rb
+++ b/app/models/phrase.rb
@@ -2,4 +2,8 @@
 
 class Phrase < ApplicationRecord
   belongs_to :note
+
+  def self.search(query)
+    where('expression_en like? OR expression_ja like?', "%#{query}%", "%#{query}%")
+  end
 end

--- a/app/views/notes/_notetable.html.slim
+++ b/app/views/notes/_notetable.html.slim
@@ -1,17 +1,3 @@
-= form_with url: search_notes_path, method: :get, local: true do |f|
-  .row.mt-3.w-50
-    .col
-      = f.text_field :query, class: "form-control", value: query, placeholder: "タイトルを入力"
-    = f.submit "検索", class: "btn btn-primary me-2", name: nil, style: "width:100px"
-
-  .row.mt-2.ms-1
-    | タグ絞り込み： 
-    .col
-      - Note.tags_on(:tags).most_used(15).each do |tag|
-        .form-check.form-check-inline
-          = check_box_tag "tags[]", tag.name, params[:tags] && params[:tags].include?(tag.name), class: 'form-check-input'
-          = "#{tag.name}(#{tag.taggings_count})"
-
 .mt-2
   table.table.table-hover
     thead

--- a/app/views/notes/index.html.slim
+++ b/app/views/notes/index.html.slim
@@ -1,3 +1,5 @@
 h1.mt-2 メモ一覧
 
-= render partial: 'notetable', locals: { notes: @notes, query: @query }
+= render partial: 'shared/search', locals: { url: search_notes_path, query: @query, target: Note.human_attribute_name(:title), tag_search: true }
+
+= render partial: 'notetable', locals: { notes: @notes }

--- a/app/views/notes/search.html.slim
+++ b/app/views/notes/search.html.slim
@@ -1,3 +1,5 @@
 h1.mt-2 メモ検索結果
 
+= render partial: 'shared/search', locals: { url: search_notes_path, query: @query, target: Note.human_attribute_name(:title), tag_search: true }
+
 = render partial: 'notetable', locals: { notes: @notes, query: @query }

--- a/app/views/phrases/_phrasetable.html.slim
+++ b/app/views/phrases/_phrasetable.html.slim
@@ -1,0 +1,13 @@
+div
+  table.table.table-hover
+    thead
+      tr
+        th= Phrase.human_attribute_name(:expression_en)
+        th= Phrase.human_attribute_name(:expression_ja)
+        th メモタイトル
+    tbody
+      - phrases.each do |phrase|
+        tr
+          td= phrase.expression_en
+          td= phrase.expression_ja
+          td= phrase.note.title

--- a/app/views/phrases/index.html.slim
+++ b/app/views/phrases/index.html.slim
@@ -2,16 +2,4 @@ h1.mt-2 語句一覧
 
 = render partial: 'shared/search', locals: { url: search_phrases_path, query: @query, target: I18n.t("tags_on.tag"), tag_search: false }
 
-div
-  table.table.table-hover
-    thead
-      tr
-        th= Phrase.human_attribute_name(:expression_en)
-        th= Phrase.human_attribute_name(:expression_ja)
-        th メモタイトル
-    tbody
-      - @phrases.each do |phrase|
-        tr
-          td= phrase.expression_en
-          td= phrase.expression_ja
-          td= phrase.note.title
+= render partial: 'phrasetable', locals: { phrases: @phrases}

--- a/app/views/phrases/index.html.slim
+++ b/app/views/phrases/index.html.slim
@@ -1,5 +1,7 @@
 h1.mt-2 語句一覧
 
+= render partial: 'shared/search', locals: { url: search_phrases_path, query: @query, target: I18n.t("tags_on.tag"), tag_search: false }
+
 div
   table.table.table-hover
     thead

--- a/app/views/phrases/search.html.slim
+++ b/app/views/phrases/search.html.slim
@@ -1,4 +1,4 @@
-h1.mt-2 語句一覧
+h1.mt-2 語句検索結果
 
 = render partial: 'shared/search', locals: { url: search_phrases_path, query: @query, target: 'キーワード', tag_search: false }
 

--- a/app/views/shared/_search.html.slim
+++ b/app/views/shared/_search.html.slim
@@ -1,0 +1,14 @@
+= form_with url: url, method: :get, local: true do |f|
+  .row.mt-3.w-50
+    .col
+      = f.text_field :query, class: "form-control", value: query, placeholder: "#{target}を入力"
+    = f.submit "検索", class: "btn btn-primary me-2", name: nil, style: "width:100px"
+
+  - if tag_search
+    .row.mt-2.ms-1
+      | タグ絞り込み： 
+      .col
+        - Note.tags_on(:tags).most_used(15).each do |tag|
+          .form-check.form-check-inline
+            = check_box_tag "tags[]", tag.name, params[:tags] && params[:tags].include?(tag.name), class: 'form-check-input'
+            = "#{tag.name}(#{tag.taggings_count})"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,11 @@ Rails.application.routes.draw do
     end
   end
 
-  get 'phrases', to: 'phrases#index'
+  resources :phrases, only: [:index] do
+    collection do
+      get :search
+    end
+  end
 
   get '*path', controller: 'application', action: 'redirect_on_404err' unless Rails.env.development?
 end


### PR DESCRIPTION
レビューをお願いいたします。

## 作業内容
- [x] 検索フォームをパーシャル化
- [x] phraseのルーティングを設定
- [x] phraseモデル，phrasesコントローラに検索用のメソッドを実装
- [x] 語句一覧画面に検索フォームを追加
- [x] 語句表示テーブルをパーシャル化
- [x] 検索結果表示用のビューを作成

## 画面
### 語句一覧
![スクリーンショット 2023-06-02 14 17 30](https://github.com/tmonma-lux/parallel_note/assets/132245602/d4092cf5-06c6-49da-a4fb-270d9ade413d)

### 語句での検索
![スクリーンショット 2023-06-02 14 18 18](https://github.com/tmonma-lux/parallel_note/assets/132245602/abf08931-7ab6-4aab-9f5e-ff77c80f9a86)

### 意味での検索
![スクリーンショット 2023-06-02 14 18 45](https://github.com/tmonma-lux/parallel_note/assets/132245602/3823c6f1-662f-409b-b480-c225c56acdf0)

## レビュー前チェック
- [x] RuboCop実行
