### PR TITLE
バリデーションエラーメッセージのスタイル修正

### DIFF
--- a/app/views/notes/_form.html.slim
+++ b/app/views/notes/_form.html.slim
@@ -1,5 +1,5 @@
 - if note_form.errors.present?
-    ul.alert.alert-danger.mt-2
+    ul.alert.alert-danger.mt-2.py-2
       .ps-3
         - note_form.errors.full_messages.each do |message|
           li = message

--- a/app/views/notes/_form.html.slim
+++ b/app/views/notes/_form.html.slim
@@ -5,10 +5,9 @@
           li = message
 
 = form_with model: note_form, url:, method:, local: true do |f|
-  .mt-3
-    .flex
-      = f.text_field :title, class: 'form-control w-60 me-3', placeholder: 'タイトルを入力してください'
-      = f.submit '保存', class: 'btn btn-primary w100px me-2'
+  .row.mt-3
+    .col-7 = f.text_field :title, class: 'form-control', placeholder: 'タイトルを入力してください'
+    = f.submit '保存', class: 'btn btn-primary w100px ms-2'
 
   .mt-3
     .flex

--- a/app/views/notes/_form.html.slim
+++ b/app/views/notes/_form.html.slim
@@ -1,7 +1,8 @@
 - if note_form.errors.present?
-    ul
-      - note_form.errors.full_messages.each do |message|
-        li = message
+    ul.alert.alert-danger.mt-2
+      .ps-3
+        - note_form.errors.full_messages.each do |message|
+          li = message
 
 = form_with model: note_form, url:, method:, local: true do |f|
   .mt-3


### PR DESCRIPTION
レビューをお願いいたします。

## 作業内容
- [x] バリデーションエラーメッセージにBootstrapのAlertスタイルを適用
- [x] バリデーションエラー発生時にタイトル入力フォームが崩れる不具合を修正

## 画面
![スクリーンショット 2023-06-16 10 36 14](https://github.com/tmonma-lux/parallel_note/assets/132245602/ba23f24e-fdbd-4c7a-a326-8860abd9eaa6)

## レビュー前チェック
- [x] RuboCop実行
- [x] slim-lint実行
