### PR TITLE
タグのインクリメンタルサーチ機能実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -153,3 +153,13 @@ ul.tagit input[type="text"] {
 .ui-widget {	
   font-size: initial;	
 }
+
+.tagit-autocomplete.ui-widget-content {
+  border-color: #ced4da;
+  width: 400px;
+}
+
+.ui-state-active {
+  border: none !important;
+  background-color: #e5e5e5 !important;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -41,6 +41,10 @@ td {
   color: #ffffff;
 }
 
+/* Note Form */
+.tag_form_error {
+  color: red;
+}
 
 /* Note Show */
 .flex {

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -15,6 +15,10 @@ class NotesController < ApplicationController
     @query = params[:query]
   end
 
+  def fetch_tag_suggestions
+    @tags = Note.tag_counts_on(:tags).where('name LIKE :tag_input', tag_input: "#{params[:tag_input]}%")
+  end
+
   def new
     @note_form = NoteForm.new
   end

--- a/app/javascript/controllers/tag_form_controller.js
+++ b/app/javascript/controllers/tag_form_controller.js
@@ -30,7 +30,10 @@ export default class extends Controller {
           });
           $('.tagit-autocomplete.ui-widget-content').addClass('form-control');
         }
-      });
+      })
+      .fail(function(){
+        $('.tag_form_error').text('タグ入力時にエラーが発生しました。');
+      })
     });
   }
 }

--- a/app/javascript/controllers/tag_form_controller.js
+++ b/app/javascript/controllers/tag_form_controller.js
@@ -6,8 +6,29 @@ import "../tag-it"
 // Connects to data-controller="tag-form"
 export default class extends Controller {
   connect() {
-    const tagForm = this.element.querySelector("#tag_field");
+    const tagForm = this.element.querySelector('#tag_field');
     $(tagForm).tagit();
-    $("ul.tagit").addClass('form-control w-auto');
+    $('ul.tagit').addClass('form-control w-auto');
+
+    $(document).on('keyup', '.tagit', function() {
+      const tag_input = $('.ui-widget-content.ui-autocomplete-input').val();
+  
+      $.ajax({
+        type: 'GET',
+        url: 'fetch_tag_suggestions',
+        data: { tag_input: tag_input },
+        dataType: 'json'
+      })
+      .done(function(data){
+        if(tag_input.length) {
+          const tag_list = data.map(function(val){
+            return val.name
+          });
+          $(tagForm).tagit({
+            availableTags: tag_list
+          });
+        }
+      });
+    });
   }
 }

--- a/app/javascript/controllers/tag_form_controller.js
+++ b/app/javascript/controllers/tag_form_controller.js
@@ -31,8 +31,8 @@ export default class extends Controller {
           $('.tagit-autocomplete.ui-widget-content').addClass('form-control');
         }
       })
-      .fail(function(){
-        $('.tag_form_error').text('タグ入力時にエラーが発生しました。');
+      .fail(function(jqXHR, textStatus, errorThrown){
+        $('.tag_form_error').text(`タグ入力時にエラーが発生しました。（${jqXHR.status} ${errorThrown}）`);
       })
     });
   }

--- a/app/javascript/controllers/tag_form_controller.js
+++ b/app/javascript/controllers/tag_form_controller.js
@@ -28,6 +28,7 @@ export default class extends Controller {
           $(tagForm).tagit({
             availableTags: tag_list
           });
+          $('.tagit-autocomplete.ui-widget-content').addClass('form-control');
         }
       });
     });

--- a/app/javascript/controllers/tag_form_controller.js
+++ b/app/javascript/controllers/tag_form_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 import "../src/jquery"
 import "jquery-ui-dist"
+// jQuery,jQuery-UIを前提とする　ファイルをimport
 import "../tag-it"
 
 // Connects to data-controller="tag-form"

--- a/app/views/notes/_form.html.slim
+++ b/app/views/notes/_form.html.slim
@@ -14,6 +14,7 @@
       .f20px.d-flex.align-items-center.me-3
         | タグ：
       = f.text_field :tag_list, id: 'tag_field'
+    .tag_form_error.mt-1
 
   .mt-4
     .f24px = NoteForm.human_attribute_name(:text)

--- a/app/views/notes/fetch_tag_suggestions.json.jbuilder
+++ b/app/views/notes/fetch_tag_suggestions.json.jbuilder
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 json.array! @tags, :name

--- a/app/views/notes/fetch_tag_suggestions.json.jbuilder
+++ b/app/views/notes/fetch_tag_suggestions.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @tags, :name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
   resources :notes do
     collection do
       get :search
+      get :fetch_tag_suggestions, defaults: { format: 'json' }
+    end
+    member do
+      get :fetch_tag_suggestions, defaults: { format: 'json' }
     end
   end
 


### PR DESCRIPTION
レビューをお願いいたします。

## 作業内容
- [x] ルーティングの設定
- [x] notesコントローラ内にタグ候補検索用のメソッドを定義
- [x] タグ候補取得用のjbuilderファイルを追加
- [x] ajax通信によるインクリメンタルサーチ機能を実装
- [x] タグ候補表示部分のデザインを変更

## 画面
### インクリメンタルサーチ
<img width="1501" alt="スクリーンショット 2023-06-20 16 46 16" src="https://github.com/tmonma-lux/parallel_note/assets/132245602/9f196cd2-2a76-4c2b-9abe-79ed99643c61">

### Ajax通信失敗時
<img width="1501" alt="スクリーンショット 2023-06-20 16 46 56" src="https://github.com/tmonma-lux/parallel_note/assets/132245602/14b7e1df-6fa8-404a-976c-b13d05f3b95a">

## レビュー前チェック
- [x] RuboCop実行
- [x] slim-lint実行
